### PR TITLE
Fixed bug 'TypeError: event.dataTransfer is undefined'

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -6,6 +6,7 @@
  *
  * License: MIT
  */
+(function () {
 angular.module('dndLists', [])
 
     /**
@@ -45,6 +46,7 @@ angular.module('dndLists', [])
     .directive('dndDraggable', ['$parse', '$timeout', 'dndDropEffectWorkaround', 'dndDragTypeWorkaround',
                         function($parse,   $timeout,   dndDropEffectWorkaround,   dndDragTypeWorkaround) {
         return function(scope, element, attr) {
+
             // Set the HTML5 draggable attribute on the element
             element.attr("draggable", "true");
 
@@ -53,6 +55,8 @@ angular.module('dndLists', [])
              * which is the primary way we communicate with the target element
              */
             element.on('dragstart', function(event) {
+		patchEvent( event );
+		
                 // Serialize the data associated with this element. IE only supports the Text drag type
                 event.dataTransfer.setData("Text", angular.toJson(scope.$eval(attr.dndDraggable)));
 
@@ -76,6 +80,8 @@ angular.module('dndLists', [])
              * we will invoke the callbacks specified with the dnd-moved or dnd-copied attribute.
              */
             element.on('dragend', function(event) {
+		patchEvent( event );
+
                 // If the dropEffect is none it means that the drag action was aborted or
                 // that the browser does not support this field. In either case we use
                 // the fallback which was initialized to none
@@ -156,6 +162,8 @@ angular.module('dndLists', [])
              * is being dragged over our list, or over an child element.
              */
             element.on('dragover', function(event) {
+		patchEvent( event );
+
                 // Disallow drop if it comes from an external source or is not text.
                 // Usually we would use a custom drag type for this, but IE doesn't support that.
                 if (!dndDragTypeWorkaround.isDragging) return true;
@@ -220,6 +228,8 @@ angular.module('dndLists', [])
              * one child element per array element.
              */
             element.on('drop', function(event) {
+		patchEvent( event );
+
                 // Unserialize the data that was serialized in dragstart. According to the HTML5 specs,
                 // the "Text" drag type will be converted to text/plain, but IE does not do that.
                 var transferredObject = JSON.parse(event.dataTransfer.getData("Text")
@@ -298,3 +308,15 @@ angular.module('dndLists', [])
      * that has been open for years: https://code.google.com/p/chromium/issues/detail?id=39399
      */
     .factory('dndDropEffectWorkaround', function(){ return {} });
+
+
+/**
+ * Workaround for bug "TypeError: event.dataTransfer is undefined" 
+ * in Firefox 31.0 (Ubuntu).
+ */
+function patchEvent ( event ) {
+    if ( undefined === event.dataTransfer ) event = event.originalEvent;
+    return event;
+};
+
+})();


### PR DESCRIPTION
The bug occurs when **jQuery** is used with **Angular**. It's because of:

> "If jQuery is available, angular.element is an alias for the jQuery function. If jQuery is not available, angular.element delegates to Angular's built-in subset of jQuery, called "jQuery lite" or "jqLite." (https://docs.angularjs.org/api/ng/function/angular.element) 

and because of jQuery event object does not have a **dataTransfer** property. (http://api.jquery.com/category/events/event-object/)
