### PR TITLE
ignore demo and json files on bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,8 @@
     "**/.*",
     "node_modules",
     "bower_components",
+    "demo",
+    "*.json",
     "test",
     "tests"
   ]


### PR DESCRIPTION
After bower install, angular-drag-and-drop-lists has unnecessary files
If you check in dependencies (as bower suggests), you end up with gigantic diffs