### PR TITLE
update simple.html to use dnd-dragstart

### DIFF
--- a/demo/simple/simple.html
+++ b/demo/simple/simple.html
@@ -7,7 +7,7 @@
          yourself using the dnd-moved attribute -->
     <li ng-repeat="item in list"
         dnd-draggable="item"
-        dnd-moved="list.splice($index, 1)"
+        dnd-dragstart="list.splice($index, 1)"
         dnd-effect-allowed="move"
         dnd-selected="models.selected = item"
         ng-class="{'selected': models.selected === item}"


### PR DESCRIPTION
use dnd-dragstart instead of dnd-moved so that the item is removed immediately when it is being moved, and so that the removal by splice works with lists that use "track by $index".

Resolves #33 