### PR TITLE
enable retention of prototypes when dragging

### DIFF
--- a/demo/advanced/advanced-frame.html
+++ b/demo/advanced/advanced-frame.html
@@ -24,4 +24,4 @@
 <div view-source="advanced"></div>
 
 <h2>Generated Model</h2>
-<pre>{{modelAsJson}}</pre>
+<pre>{{toJson(model)}}</pre>

--- a/demo/advanced/advanced.html
+++ b/demo/advanced/advanced.html
@@ -8,9 +8,9 @@
         dnd-draggable="items"
         dnd-type="'containerType'"
         dnd-effect-allowed="copyMove"
-        dnd-dragstart="logEvent('Started to drag a container', event)"
-        dnd-moved="containers.splice($index, 1); logEvent('Container moved', event)"
-        dnd-copied="logEvent('Container copied', event)">
+        dnd-dragstart="logEvent('Started to drag a container', event, item)"
+        dnd-moved="containers.splice($index, 1); logEvent('Container moved', event, item);"
+        dnd-copied="logEvent('Container copied', event, item)">
         <div class="container-element box box-blue">
             <h3>Container</h3>
             <ul dnd-list="items"
@@ -24,9 +24,9 @@
                     dnd-draggable="item"
                     dnd-type="'itemType'"
                     dnd-effect-allowed="copyMove"
-                    dnd-dragstart="logEvent('Started to drag an item', event)"
-                    dnd-moved="items.splice($index, 1); logEvent('Item moved', event)"
-                    dnd-copied="logEvent('Item copied', event)">
+                    dnd-dragstart="logEvent('Started to drag an item', event, item)"
+                    dnd-moved="items.splice($index, 1); logEvent('Item moved', event, item); item.moved()"
+                    dnd-copied="logEvent('Item copied', event, item); item.copied()">
                     {{item.label}}
                 </li>
             </ul>

--- a/demo/advanced/advanced.js
+++ b/demo/advanced/advanced.js
@@ -14,18 +14,33 @@ angular.module("demo").controller("AdvancedDemoController", function($scope) {
         return item;
     };
 
-    $scope.logEvent = function(message, event) {
-        console.log(message, '(triggered by the following', event.type, 'event)');
+    $scope.logEvent = function(message, event, item) {
+        console.log(message + ' (triggered by the following ' + event.type + ' event)%s',
+          (item ? ' of "' + item.label + '"': ''));
         console.log(event);
     };
 
-    $scope.logListEvent = function(action, event, index, external, type) {
+    $scope.logListEvent = function(action, event, index, external, type, item) {
         var message = external ? 'External ' : '';
         message += type + ' element is ' + action + ' position ' + index;
-        $scope.logEvent(message, event);
+        $scope.logEvent(message, event, item);
     };
 
     $scope.model = [];
+
+    var Item = function Item(label) {
+      this.label = label;
+      this.moveCount = 0;
+      this.copyCount = 0;
+    };
+
+    Item.prototype.moved = function moved() {
+      this.moveCount++;
+    };
+
+    Item.prototype.copied = function copied() {
+      this.copyCount++;
+    };
 
     // Initialize model
     var id = 10;
@@ -34,13 +49,15 @@ angular.module("demo").controller("AdvancedDemoController", function($scope) {
         for (var j = 0; j < 2; ++j) {
             $scope.model[i].push([]);
             for (var k = 0; k < 7; ++k) {
-                $scope.model[i][j].push({label: 'Item ' + id++});
+                $scope.model[i][j].push(new Item('Item ' + id++));
             }
         }
     }
 
-    $scope.$watch('model', function(model) {
-        $scope.modelAsJson = angular.toJson(model, true);
-    }, true);
+    // this will replace the $watch, which will no longer work, because the
+    // item references do not change.
+    $scope.toJson = function toJson(model) {
+      return angular.toJson(model, true);
+    };
 
 });


### PR DESCRIPTION
- currently, the hack to get around lack of IE support for custom `dataTransfer` types is debilitating
- practically, when items are dropped, they lose their reference and any associated prototype, because they are serialized and deserialized to and from JSON
- this PR works around that by implementing a simple cache that the directives use to store and retrieve data
- transferred object is always passed into event handler(s) when possible
- demo `demo/advanced` is now updated to use this functionality

Without functional tests, it's hard to say whether or not this strategy is susceptible to race conditions.  We aren't targeting older browsers, but I have tested this on current versions of Chrome, Safari and Firefox, and it works in all three.