### PR TITLE
Support for drag handles via dnd-handle directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Download `angular-drag-and-drop-lists.js` (or the minified version) and include 
 Use the dnd-draggable directive to make your element draggable
 
 **Attributes**
+
 * `dnd-draggable` Required attribute. The value has to be an object that represents the data of the element. In case of a drag and drop operation the object will be serialized and unserialized on the receiving end.
 * `dnd-selected` Callback that is invoked when the element was clicked but not dragged. The original click event will be provided in the local `event` variable. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/nested) 
 * `dnd-effect-allowed` Use this attribute to limit the operations that can be performed. Options are:
@@ -55,13 +56,24 @@ Use the dnd-draggable directive to make your element draggable
 * `dnd-disable-if` You can use this attribute to dynamically disable the draggability of the element. This is useful if you have certain list items that you don't want to be draggable, or if you want to disable drag & drop completely without having two different code branches (e.g. only allow for admins). *Note*: If your element is not draggable, the user is probably able to select text or images inside of it. Since a selection is always draggable, this breaks your UI. You most likely want to disable user selection via CSS (see [user-select](http://stackoverflow.com/a/4407335)). [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/types) 
 
 **CSS classes**
+
 * `dndDragging` This class will be added to the element while the element is being dragged. It will affect both the element you see while dragging and the source element that stays at it's position. Do not try to hide the source element with this class, because that will abort the drag operation.
 * `dndDraggingSource` This class will be added to the element after the drag operation was started, meaning it only affects the original element that is still at it's source position, and not the "element" that the user is dragging with his mouse pointer
+
+### dnd-handle directive
+You can use the dnd-handle inside your draggable element to make only specific descendant elements of it start the drag. These are commonly referred to as drag handles or grabbers.
+
+This directive is used without a value.
+
+    <li dnd-draggable="item">
+      <span dnd-grabber></span> {{ item.label }}
+    </li>
 
 ### dnd-list directive
 Use the dnd-list attribute to make your list element a dropzone. Usually you will add a single li element as child with the ng-repeat directive. If you don't do that, we will not be able to position the dropped element correctly. If you want your list to be sortable, also add the dnd-draggable directive to your li element(s). Both the dnd-list and it's direct children must have position: relative CSS style, otherwise the positioning algorithm will not be able to determine the correct placeholder position in all browsers.
 
 **Attributes**
+
 * `dnd-list` Required attribute. The value has to be the array in which the data of the dropped element should be inserted.
 * `dnd-allowed-types` Optional array of allowed item types. When used, only items that had a matching dnd-type attribute will be dropable. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/types) 
 * `dnd-disable-if` Optional boolean expresssion. When it evaluates to true, no dropping into the list is possible. Note that this also disables rearranging items inside the list. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/types) 
@@ -80,17 +92,16 @@ Use the dnd-list attribute to make your list element a dropzone. Usually you wil
 * `dnd-external-sources` Optional boolean expression. When it evaluates to true, the list accepts drops from sources outside of the current browser tab. This allows to drag and drop accross different browser tabs. Note that this will allow to drop arbitrary text into the list, thus it is highly recommended to implement the dnd-drop callback to check the incoming element for sanity. Furthermore, the dnd-type of external sources can not be determined, therefore do not rely on restrictions of dnd-allowed-type. Also note that this feature does not work very well in Internet Explorer. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/advanced)
 
 **CSS classes**
+
 * `dndPlaceholder` When an element is dragged over the list, a new placeholder child element will be added. This element is of type li and has the class dndPlaceholder set.
 * `dndDragover` This class will be added to the list while an element is being dragged over the list.
 
 ### Required CSS styles 
 Both the dnd-list and it's children require relative positioning, so that the directive can determine the mouse position relative to the list and thus calculate the correct drop position.
 
-<pre>
-ul[dnd-list], ul[dnd-list] > li { 
-    position: relative;
-}
-</pre>
+    ul[dnd-list], ul[dnd-list] > li { 
+      position: relative;
+    }
 
 *Since 1.2.0 `pointer-events: none` is no longer required*
 

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -62,101 +62,104 @@ angular.module('dndLists', [])
    */
   .directive('dndDraggable', ['$parse', '$timeout', 'dndDropEffectWorkaround', 'dndDragTypeWorkaround',
                       function($parse,   $timeout,   dndDropEffectWorkaround,   dndDragTypeWorkaround) {
-    return function(scope, element, attr) {
-      // Set the HTML5 draggable attribute on the element
-      element.attr("draggable", "true");
+    return {
+      controller: ['$scope', '$element', '$attrs',
+           function($scope,   $element,   $attrs) {
+        // Set the HTML5 draggable attribute on the element
+        $element.attr("draggable", "true");
 
-      // If the dnd-disable-if attribute is set, we have to watch that
-      if (attr.dndDisableIf) {
-        scope.$watch(attr.dndDisableIf, function(disabled) {
-          element.attr("draggable", !disabled);
-        });
-      }
+        // If the dnd-disable-if attribute is set, we have to watch that
+        if ($attrs.dndDisableIf) {
+          $scope.$watch($attrs.dndDisableIf, function(disabled) {
+            $element.attr("draggable", !disabled);
+          });
+        }
 
-      /**
-       * When the drag operation is started we have to prepare the dataTransfer object,
-       * which is the primary way we communicate with the target element
-       */
-      element.on('dragstart', function(event) {
-        event = event.originalEvent || event;
+        /**
+         * When the drag operation is started we have to prepare the dataTransfer object,
+         * which is the primary way we communicate with the target element
+         */
+        $element.on('dragstart', function(event) {
+          event = event.originalEvent || event;
 
-        // Serialize the data associated with this element. IE only supports the Text drag type
-        event.dataTransfer.setData("Text", angular.toJson(scope.$eval(attr.dndDraggable)));
+          // Serialize the data associated with this element. IE only supports the Text drag type
+          event.dataTransfer.setData("Text", angular.toJson($scope.$eval($attrs.dndDraggable)));
 
-        // Only allow actions specified in dnd-effect-allowed attribute
-        event.dataTransfer.effectAllowed = attr.dndEffectAllowed || "move";
+          // Only allow actions specified in dnd-effect-allowed attribute
+          event.dataTransfer.effectAllowed = $attrs.dndEffectAllowed || "move";
 
-        // Add CSS classes. See documentation above
-        element.addClass("dndDragging");
-        $timeout(function() { element.addClass("dndDraggingSource"); }, 0);
+          // Add CSS classes. See documentation above
+          $element.addClass("dndDragging");
+          $timeout(function() { $element.addClass("dndDraggingSource"); }, 0);
 
-        // Workarounds for stupid browsers, see description below
-        dndDropEffectWorkaround.dropEffect = "none";
-        dndDragTypeWorkaround.isDragging = true;
+          // Workarounds for stupid browsers, see description below
+          dndDropEffectWorkaround.dropEffect = "none";
+          dndDragTypeWorkaround.isDragging = true;
 
-        // Save type of item in global state. Usually, this would go into the dataTransfer
-        // typename, but we have to use "Text" there to support IE
-        dndDragTypeWorkaround.dragType = attr.dndType ? scope.$eval(attr.dndType) : undefined;
+          // Save type of item in global state. Usually, this would go into the dataTransfer
+          // typename, but we have to use "Text" there to support IE
+          dndDragTypeWorkaround.dragType = $attrs.dndType ? $scope.$eval($attrs.dndType) : undefined;
 
-        // Invoke callback
-        $parse(attr.dndDragstart)(scope, {event: event});
+          // Invoke callback
+          $parse($attrs.dndDragstart)($scope, {event: event});
 
-        event.stopPropagation();
-      });
-
-      /**
-       * The dragend event is triggered when the element was dropped or when the drag
-       * operation was aborted (e.g. hit escape button). Depending on the executed action
-       * we will invoke the callbacks specified with the dnd-moved or dnd-copied attribute.
-       */
-      element.on('dragend', function(event) {
-        event = event.originalEvent || event;
-
-        // Invoke callbacks. Usually we would use event.dataTransfer.dropEffect to determine
-        // the used effect, but Chrome has not implemented that field correctly. On Windows
-        // it always sets it to 'none', while Chrome on Linux sometimes sets it to something
-        // else when it's supposed to send 'none' (drag operation aborted).
-        var dropEffect = dndDropEffectWorkaround.dropEffect;
-        scope.$apply(function() {
-          switch (dropEffect) {
-            case "move":
-              $parse(attr.dndMoved)(scope, {event: event});
-              break;
-
-            case "copy":
-              $parse(attr.dndCopied)(scope, {event: event});
-              break;
-          }
+          event.stopPropagation();
         });
 
-        // Clean up
-        element.removeClass("dndDragging");
-        element.removeClass("dndDraggingSource");
-        dndDragTypeWorkaround.isDragging = false;
-        event.stopPropagation();
-      });
+        /**
+         * The dragend event is triggered when the element was dropped or when the drag
+         * operation was aborted (e.g. hit escape button). Depending on the executed action
+         * we will invoke the callbacks specified with the dnd-moved or dnd-copied attribute.
+         */
+        $element.on('dragend', function(event) {
+          event = event.originalEvent || event;
 
-      /**
-       * When the element is clicked we invoke the callback function
-       * specified with the dnd-selected attribute.
-       */
-      element.on('click', function(event) {
-        event = event.originalEvent || event;
+          // Invoke callbacks. Usually we would use event.dataTransfer.dropEffect to determine
+          // the used effect, but Chrome has not implemented that field correctly. On Windows
+          // it always sets it to 'none', while Chrome on Linux sometimes sets it to something
+          // else when it's supposed to send 'none' (drag operation aborted).
+          var dropEffect = dndDropEffectWorkaround.dropEffect;
+          $scope.$apply(function() {
+            switch (dropEffect) {
+              case "move":
+                $parse($attrs.dndMoved)($scope, {event: event});
+                break;
 
-        scope.$apply(function() {
-          $parse(attr.dndSelected)(scope, {event: event});
+              case "copy":
+                $parse($attrs.dndCopied)($scope, {event: event});
+                break;
+            }
+          });
+
+          // Clean up
+          $element.removeClass("dndDragging");
+          $element.removeClass("dndDraggingSource");
+          dndDragTypeWorkaround.isDragging = false;
+          event.stopPropagation();
         });
 
-        event.stopPropagation();
-      });
+        /**
+         * When the element is clicked we invoke the callback function
+         * specified with the dnd-selected attribute.
+         */
+        $element.on('click', function(event) {
+          event = event.originalEvent || event;
 
-      /**
-       * Workaround to make element draggable in IE9
-       */
-      element.on('selectstart', function() {
-        if (this.dragDrop) this.dragDrop();
-        return false;
-      });
+          $scope.$apply(function() {
+            $parse($attrs.dndSelected)($scope, {event: event});
+          });
+
+          event.stopPropagation();
+        });
+
+        /**
+         * Workaround to make element draggable in IE9
+         */
+        $element.on('selectstart', function() {
+          if (this.dragDrop) this.dragDrop();
+          return false;
+        });
+      }]
     };
   }])
 

--- a/demo/advanced/advanced-frame.html
+++ b/demo/advanced/advanced-frame.html
@@ -13,6 +13,8 @@
         verifies that the dropped element is of the desired format.</li>
     <li><strong>dnd-effect-allowed:</strong> This attribute is set to 'copyMove' in this example, which means that the user can choose
         whether to copy or move an element by holding down the Ctrl key. Note that this doesn't work in Chrome very well.</li>
+    <li><strong>dnd-handle:</strong> Dragging can be restricted to only start on specific elements inside the draggable element.
+      In this example, the container items can only be dragged from their title bar.</li>
 </ul>
 
 <div class="advancedDemo row">

--- a/demo/advanced/advanced.css
+++ b/demo/advanced/advanced.css
@@ -11,6 +11,8 @@
 
 /***************************** Dropzone Styling *****************************/
 
+.advancedDemo .container-element > h3 { cursor: move; }
+
 /**
  * The dnd-list should always have a min-height,
  * otherwise you can't drop to it once it's empty

--- a/demo/advanced/advanced.html
+++ b/demo/advanced/advanced.html
@@ -12,7 +12,7 @@
         dnd-moved="containers.splice($index, 1); logEvent('Container moved', event)"
         dnd-copied="logEvent('Container copied', event)">
         <div class="container-element box box-blue">
-            <h3>Container</h3>
+            <h3 dnd-handle>Container</h3>
             <ul dnd-list="items"
                 dnd-allowed-types="['itemType']"
                 dnd-horizontal-list="true"


### PR DESCRIPTION
Add support for drag handles using a new `dnd-handle` directive. See #31 and #35.