### PR TITLE
Don't stop `selectstart` events

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -155,7 +155,6 @@ angular.module('dndLists', [])
        */
       element.on('selectstart', function() {
         if (this.dragDrop) this.dragDrop();
-        return false;
       });
     };
   }])


### PR DESCRIPTION
The IE9 workaround stops selection inside draggables in all browsers.
With handles support added (see #31, #35, and #48), it is possible to
allow both dragging and selection inside the same element, if it wasn’t
for this issue.

Stopping default handling and/or propagation does not seem to actually
be necessary to support dragging in my testing on IE9, so this commit
just removes the return statement.