### PR TITLE
Fix for IE9 Double Click and Missed Dropzone

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -131,7 +131,7 @@ angular.module('dndLists', [])
 
         // Clean up
         element.removeClass("dndDragging");
-        element.removeClass("dndDraggingSource");
+        $timeout(function() { element.removeClass("dndDraggingSource"); }, 0);
         dndDragTypeWorkaround.isDragging = false;
         event.stopPropagation();
       });


### PR DESCRIPTION
Since the addition of the .dndDraggingSource class is in a $timeout,
there is no guarantee that this class exists at the time of removal.
In IE9 this appears to be an issue because the the drag operation
are event loop blocking.

Potential fix for #21.

I didn't minify code/package anything, I'll leave that a release. Also, as a side note that one might consider: while the timeout might be necessary, perhaps it might be worth just using a regular setTimeout instead of $timeout for the add and removal of this class. There's no need to fire a potential $digest for this.