### PR TITLE
add css class for copied source element

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -89,6 +89,8 @@ angular.module('dndLists', [])
         // Add CSS classes. See documentation above
         element.addClass("dndDragging");
         $timeout(function() { element.addClass("dndDraggingSource"); }, 0);
+        if (attr.dndCopied)
+          element.addClass("dndCopiedSource");
 
         // Workarounds for stupid browsers, see description below
         dndDropEffectWorkaround.dropEffect = "none";
@@ -132,6 +134,10 @@ angular.module('dndLists', [])
         // Clean up
         element.removeClass("dndDragging");
         element.removeClass("dndDraggingSource");
+        
+        if (attr.dndCopied)
+          element.removeClass("dndCopiedSource");
+
         dndDragTypeWorkaround.isDragging = false;
         event.stopPropagation();
       });


### PR DESCRIPTION
The default behavior for move is to hide the source element.  However, for a copyMove action, the source element shouldn't be hidden to indicate it's a copy rather than a move.  Add a css class.