### PR TITLE
Add 'main' field to package.json for browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Angular directives for sorting nested lists using the HTML5 Drag and Drop API",
     "repository": "https://github.com/marceljuenemann/angular-drag-and-drop-lists",
     "license": "MIT",
+    "main": "angular-drag-and-drop-lists.js",
     "devDependencies": {
         "http-server": "~0.6.1"
     },


### PR DESCRIPTION
Same as in the `bower.json`, allows installation and usage like:

    npm install marceljuenemann/angular-drag-and-drop-lists
    # Add 'require("angular-drag-and-drop-lists");' to app.js somewhere before 
    # calling 'angular.module('myApp', ['dndLists', ...]);'
    browserify app.js > bundle.js
