### PR TITLE
Dragend

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -131,7 +131,7 @@ angular.module('dndLists', [])
               break;
           }
 
-          $parse(attr.dndDragend)(scope, {event: event, dropEffet: dropEffect});
+          $parse(attr.dndDragend)(scope, {event: event, dropEffect: dropEffect});
         });
 
         // Clean up

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -37,6 +37,9 @@ angular.module('dndLists', [])
    *                      event variable.
    * - dnd-dragstart      Callback that is invoked when the element was dragged. The original
    *                      dragstart event will be provided in the local event variable.
+   * - dnd-dragend        Callback that is invoked when the drag operation ended. The original
+   *                      dragend event will be provided in the local event variable. Also the dropEffect
+   *                      will be provided as local variable.
    * - dnd-type           Use this attribute if you have different kinds of items in your
    *                      application and you want to limit which items can be dropped into which
    *                      lists. Combine with dnd-allowed-types on the dnd-list(s). This attribute
@@ -127,6 +130,8 @@ angular.module('dndLists', [])
               $parse(attr.dndCopied)(scope, {event: event});
               break;
           }
+
+          $parse(attr.dndDragend)(scope, {event: event, dropEffet: dropEffect});
         });
 
         // Clean up


### PR DESCRIPTION
Adding a dragend attribute handler which can be used as counterpart to dragstart. It is not supposed to replace the move, copy (and in future release the "cancel") event handlers but if you have some logic that needs to revert something you've setup on dragstart it can become cumbersome because you have to implement all three handlers to be sure to catch every case of a dragend. 