### PR TITLE
Adding callback for drop completion

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -337,6 +337,11 @@ angular.module('dndLists', [])
         } else {
           dndDropEffectWorkaround.dropEffect = event.dataTransfer.dropEffect;
         }
+        
+        // Underlying collection is updated, execute callback function
+        if (attr.onDropCompleted){
+          $parse(attr.onDropSuccess)(scope, {$event: event});
+        }
 
         // Clean up
         stopDragover();


### PR DESCRIPTION
Enables me to perform an http request after the underlying collection is updated post drop. I did not update the min version, as you'll probably end up merging multiple pull requests at a time.