### PR TITLE
Added an optional parameter for specifying custom placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Use the dnd-list attribute to make your list element a dropzone. Usually you wil
 **Attributes**
 * `dnd-list` Required attribute. The value has to be the array in which the data of the dropped element should be inserted.
 * `dnd-allowed-types` Optional array of allowed item types. When used, only items that had a matching dnd-type attribute will be dropable. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/types) 
+* `dnd-element-template` Optional template of the placeholder item. <li></li> used by default. 
 * `dnd-disable-if` Optional boolean expresssion. When it evaluates to true, no dropping into the list is possible. Note that this also disables rearranging items inside the list. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/types) 
 * `dnd-horizontal-list` Optional boolean expresssion. When it evaluates to true, the positioning algorithm will use the left and right halfs of the list items instead of the upper and lower halfs. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/advanced)
 * `dnd-dragover` Optional expression that is invoked when an element is dragged over the list. If the expression is set, but does not return true, the element is not allowed to be dropped. The following variables will be available:

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -174,6 +174,10 @@ angular.module('dndLists', [])
    *                        the dropped element should be inserted.
    * - dnd-allowed-types    Optional array of allowed item types. When used, only items that had a
    *                        matching dnd-type attribute will be dropable.
+   *
+   * - dnd-element-template
+   *                        List element template, "<li></li>" used by default
+   *
    * - dnd-disable-if       Optional boolean expresssion. When it evaluates to true, no dropping
    *                        into the list is possible. Note that this also disables rearranging
    *                        items inside the list.
@@ -213,7 +217,9 @@ angular.module('dndLists', [])
     return function(scope, element, attr) {
       // While an element is dragged over the list, this placeholder element is inserted
       // at the location where the element would be inserted after dropping
-      var placeholder = angular.element("<li class='dndPlaceholder'></li>");
+      var elTemplate = attr.dndElementTemplate || "<li></li>";
+      var placeholder = angular.element(elTemplate);
+      placeholder.addClass("dndPlaceholder");
       var placeholderNode = placeholder[0];
       var listNode = element[0];
 


### PR DESCRIPTION
I wanted to use this directive with tables, so I added the ability to use something like this:

```html
<table>
  <tbody dnd-list="cats" dnd-element-template="<tr><td colspan='4'>You'll drop the cat here</tr>"
    <tr ng-repeat="cat in cats" dnd-draggable="cat"> <!--etc-->
  </tbody>
</table>
```


So I added that functionality. There should probably be an option to use an external template as well, but I haven't implemented it.