### PR TITLE
mobile dnd polyfill support

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -221,6 +221,18 @@ angular.module('dndLists', [])
       var externalSources = attr.dndExternalSources && scope.$eval(attr.dndExternalSources);
 
       /**
+       * The dragenter is triggered prior to the dragover and to allow
+       * a drop the event handler must preventDefault().
+       */
+      element.on('dragenter', function (event) {
+        event = event.originalEvent || event;
+
+        if (!isDropAllowed(event)) return true;
+
+        event.preventDefault();
+      });
+
+      /**
        * The dragover event is triggered "every few hundred milliseconds" while an element
        * is being dragged over our list, or over an child element.
        */


### PR DESCRIPTION
Hi,

I've done some work on the mobile drag and drop polyfill:
https://github.com/timruffles/ios-html5-drag-drop-shim/pull/44

It aims to implement the HTML5 drag and drop spec as closely as possible, which worked out pretty well.
You can check out the polyfill in combination with your module here:
https://github.com/reppners/angular-drag-and-drop-lists/tree/mobile-polyfill-compatibility
A `bower install` should pull in the polyfill.

The reason I need an addition in your module is because the browser implementations are doing something different than is written in the spec. If the spec is implemented strictly it requires to handle the `dragenter`-event. Browsers seem to not require it being handled, but the polyfill does because otherwise the algorithm defined in the spec isn't working. 

I think browsers are doing some magic by checking if an event handler did even exist for the event and if none existed they silently allow the drop.

Anyways.. the additions required are small so I hope you don't mind pulling them in to make the polyfill work for everybody using this library, which would result in "official" support for all mobile browsers when using this library.

Cheers