### PR TITLE
Added main file reference into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "angular-drag-and-drop-lists",
+    "main": "angular-drag-and-drop-lists.js",
     "version": "1.3.0",
     "description": "Angular directives for sorting nested lists using the HTML5 Drag and Drop API",
     "repository": "https://github.com/marceljuenemann/angular-drag-and-drop-lists",


### PR DESCRIPTION
Hello,

I'm using your directive in my project but I'd like to use as an independent CommonJS module. To allow it, I needed to add the main script reference into package.json to make this directive as an external module that can be "required".
It's a small change but it'll be very useful when someone try to use your directive in this scenario.

If you have any doubt let me know.