### PR TITLE
Don't stop propagation of click event if dnd is disabled

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -158,7 +158,9 @@ angular.module('dndLists', [])
         });
 
         // Prevent triggering dndSelected in parant elements.
-        event.stopPropagation();
+        if ($element.attr('draggable') == 'true') {
+          event.stopPropagation();
+        }
       });
 
       /**


### PR DESCRIPTION
Don't stop propagation of click event if dnd is disabled. Fixes 131

Don't know how you typically generate the min file, but I've updated the non-minified file.