### PR TITLE
Insert item at correct index for filtered lists.

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -429,7 +429,7 @@ angular.module('dndLists', [])
         var list = sibling.parent("[dnd-list]").attr("dnd-list");
 
         var scope = sibling.scope();
-        var result = scope[list].indexOf(scope[draggable]);
+        var result = scope.$eval(list).indexOf(scope.$eval(draggable));
 
         if (direction == -1)
           result += 1;

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -328,7 +328,7 @@ angular.module('dndLists', [])
         }
 
         // Invoke the callback, which can transform the transferredObject and even abort the drop.
-        var index = getPlaceholderIndex();
+        var index = getInsertIndex();
         if (attr.dndDrop) {
           transferredObject = invokeCallback(attr.dndDrop, event, index, transferredObject);
           if (!transferredObject) {
@@ -411,6 +411,30 @@ angular.module('dndLists', [])
           }
         });
         return placeholder || angular.element("<li class='dndPlaceholder'></li>");
+      }
+
+      /**
+       * We use the previous or next item's index of the original list to find the insert id
+       */
+      function getInsertIndex() {
+        var index = getPlaceholderIndex();
+        var direction = index == 0 ? 1 : -1;
+
+        index += direction;
+        if (index > listNode.children.length)
+          return 0;
+
+        var sibling = $(listNode.children[index]);
+        var draggable = sibling.attr("dnd-draggable");
+        var list = sibling.parent("[dnd-list]").attr("dnd-list");
+
+        var scope = sibling.scope();
+        var result = scope[list].indexOf(scope[draggable]);
+
+        if (direction == -1)
+          result += 1;
+        
+        return result;
       }
 
       /**

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -417,21 +417,17 @@ angular.module('dndLists', [])
        * We use the previous or next item's index of the original list to find the insert id
        */
       function getInsertIndex() {
-        var index = getPlaceholderIndex();
-        var direction = index == 0 ? 1 : -1;
-
-        index += direction;
-        if (index > listNode.children.length)
-          return 0;
-
-        var sibling = $(listNode.children[index]);
+        var prevSibling = $(placeholderNode).prevAll("[dnd-draggable]").eq(0);
+        var nextSibling = $(placeholderNode).nextAll("[dnd-draggable]").eq(0);
+        
+        var sibling = prevSibling.length == 1 ? prevSibling : nextSibling;
         var draggable = sibling.attr("dnd-draggable");
         var list = sibling.parent("[dnd-list]").attr("dnd-list");
 
         var scope = sibling.scope();
         var result = scope.$eval(list).indexOf(scope.$eval(draggable));
 
-        if (direction == -1)
+        if (prevSibling.length == 1)
           result += 1;
         
         return result;


### PR DESCRIPTION
With this change, the moved/copied item is not placed with the index of the placerholder in the DOM list, but rather by comparing the indices of the elements next to the placeholder. This way, if you have a list where you filter out elements, you still insert the dropped elements at the correct position.