### PR TITLE
Add dragged item to dndPlaceholder scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Use the dnd-list attribute to make your list element a dropzone. Usually you wil
 * `dnd-inserted` Optional expression that is invoked after a drop if the element was actually inserted into the list. The same local variables as for `dnd-drop` will be available. Note that for reorderings inside the same list the old element will still be in the list due to the fact that `dnd-moved` was not called yet. [Demo](http://marceljuenemann.github.io/angular-drag-and-drop-lists/demo/#/advanced)
 
 **CSS classes**
-* `dndPlaceholder` When an element is dragged over the list, a new placeholder child element will be added. This element is of type `li` and has the class `dndPlaceholder` set. Alternatively, you can define your own placeholder by creating a child element with `dndPlaceholder` class.
+* `dndPlaceholder` When an element is dragged over the list, a new placeholder child element will be added. This element is of type `li` and has the class `dndPlaceholder` set. Alternatively, you can define your own placeholder by creating a child element with `dndPlaceholder` class.  The currently dragged item is accessable in the `draggedItem` scope property.
 * `dndDragover` This class will be added to the list while an element is being dragged over the list.
 
 ## dnd-nodrag directive


### PR DESCRIPTION
Gives `dndPlaceholder` its own scope and will populate the `draggedItem` property when an item is dragged over the `dndList`.

This is particularly useful when list items are sized according to content.  Applying this pull request allows the placeholder content to accurately represent the dragged item.

Fixes #189