### PR TITLE
Allow for margin around list elements

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -295,6 +295,9 @@ angular.module('dndLists', [])
             }
           }
         } else {
+          // This branch is reached when we are dragging directly over the list element.
+          // This is for IE, which only fires events on the list directly, and for
+          // list elements with margin between them.
           var index = findInsertPoint(event);
           insertPlaceholderAt(index);
         }
@@ -403,6 +406,10 @@ angular.module('dndLists', [])
         }, 100);
       });
 
+      /**
+       * Find the insertion point in the list by binary search of the midpoint
+       * of the elements in the list.
+       */
       function findInsertPoint (event) {
         var value = horizontal ? event.clientX : event.clientY;
         var low = 0;

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -406,7 +406,15 @@ angular.module('dndLists', [])
       function findInsertPoint (event) {
         var value = horizontal ? event.clientX : event.clientY;
         var low = 0;
-        var array = element.children();
+
+        var array = [];
+
+        angular.forEach(element.children(), function (node) {
+          if (node !== placeholderNode) {
+            array.push(node);
+          }
+        });
+
         var high = array.length;
 
         while (low < high) {

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -278,29 +278,8 @@ angular.module('dndLists', [])
           element.append(placeholder);
         }
 
-        if (event.target !== listNode) {
-          // Try to find the node direct directly below the list node.
-          var listItemNode = event.target;
-          while (listItemNode.parentNode !== listNode && listItemNode.parentNode) {
-            listItemNode = listItemNode.parentNode;
-          }
-
-          if (listItemNode.parentNode === listNode && listItemNode !== placeholderNode) {
-            // If the mouse pointer is in the upper half of the child element,
-            // we place it before the child element, otherwise below it.
-            if (isMouseInFirstHalf(event, listItemNode)) {
-              listNode.insertBefore(placeholderNode, listItemNode);
-            } else {
-              listNode.insertBefore(placeholderNode, listItemNode.nextSibling);
-            }
-          }
-        } else {
-          // This branch is reached when we are dragging directly over the list element.
-          // This is for IE, which only fires events on the list directly, and for
-          // list elements with margin between them.
-          var index = findInsertPoint(event);
-          insertPlaceholderAt(index);
-        }
+        var index = findInsertPoint(event);
+        insertPlaceholderAt(index);
 
         // At this point we invoke the callback, which still can disallow the drop.
         // We can't do this earlier because we want to pass the index of the placeholder.

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -318,12 +318,12 @@ angular.module('dndLists', [])
        * Insert the placeholder node at the given index
        */
       function insertPlaceholderAt (index) {
-        var children = element.children();
+        var children = listChildren();
 
-        if (index < children.length) {
-          angular.element(children[index]).before(placeholderNode);
+        if (index <= 0) {
+          angular.element(listNode).prepend(placeholderNode);
         } else {
-          angular.element(children[children.length]).after(placeholderNode);
+          angular.element(children[index - 1]).after(placeholderNode);
         }
       }
 
@@ -407,13 +407,9 @@ angular.module('dndLists', [])
       });
 
       /**
-       * Find the insertion point in the list by binary search of the midpoint
-       * of the elements in the list.
+       * Get the child nodes, excluding the placeholder
        */
-      function findInsertPoint (event) {
-        var value = horizontal ? event.clientX : event.clientY;
-        var low = 0;
-
+      function listChildren () {
         var array = [];
 
         angular.forEach(element.children(), function (node) {
@@ -421,6 +417,19 @@ angular.module('dndLists', [])
             array.push(node);
           }
         });
+
+        return array;
+      }
+
+      /**
+       * Find the insertion point in the list by binary search of the midpoint
+       * of the elements in the list.
+       */
+      function findInsertPoint (event) {
+        var value = horizontal ? event.clientX : event.clientY;
+        var low = 0;
+
+        var array = listChildren();
 
         var high = array.length;
 


### PR DESCRIPTION
... including an arbitrarily long tail of empty list space after the list elements.

Currently it gets confused when it's over the list and generates a lot of "wobble" as it cycles between two insertion points.

It uses a binary search of the midpoints of the list elements to determine insertion point.

