### PR TITLE
adds draggable="true" to simple-demo markup

### DIFF
--- a/demo/simple/simple.html
+++ b/demo/simple/simple.html
@@ -11,6 +11,7 @@
         dnd-effect-allowed="move"
         dnd-selected="models.selected = item"
         ng-class="{'selected': models.selected === item}"
+        draggable="true"
         >
         {{item.label}}
     </li>


### PR DESCRIPTION
A fix for new users. `draggable="true"` may need to be included for dragging functionality to work. Somehow, it was being automatically appended in the demo http-server, but isn't doing so in outside projects (Rails server). I realize this is a basic HTML attribute, but it could be considered for sake of completeness, as it is a draggable attribute.

Screenshot from documentation.
<img width="1221" alt="screen shot 2016-05-17 at 12 21 44 am" src="https://cloud.githubusercontent.com/assets/14326883/15305842/ffcbdc66-1bc5-11e6-841c-6838f4141821.png">