### PR TITLE
Fixes issue of dndDragover class being added/removed repeatedly

### DIFF
--- a/test/dndListSpec.js
+++ b/test/dndListSpec.js
@@ -261,27 +261,58 @@ describe('dndList', function() {
       event._triggerOn(element);
     });
 
-    it('removes the dndDragover CSS class', function() {
+    it('removes the dndDragover CSS class after a timeout', inject(function($timeout) {
       expect(element.hasClass('dndDragover')).toBe(true);
       createEvent('dragleave')._triggerOn(element);
+      expect(element.hasClass('dndDragover')).toBe(true);
+      $timeout.flush(50);
       expect(element.hasClass('dndDragover')).toBe(false);
-    });
+    }));
 
     it('removes the placeholder after a timeout', inject(function($timeout) {
       expect(element.children().length).toBe(4);
       createEvent('dragleave')._triggerOn(element);
-      $timeout.flush(50);
+      $timeout.flush(25);
       expect(element.children().length).toBe(4);
-      $timeout.flush(50);
+      $timeout.flush(25);
       expect(element.children().length).toBe(3);
     }));
 
-    it('does not remove the placeholder if dndDragover was set again', inject(function($timeout) {
+    //deprecated test based on the fact that we're not looking at "isStillDragging" flag to determine if we should 
+    //remove placeholder
+    xit('does not remove the placeholder if dndDragover was set again', inject(function($timeout) {
       createEvent('dragleave')._triggerOn(element);
       element.addClass('dndDragover');
       $timeout.flush(1000);
       expect(element.children().length).toBe(4);
     }));
+
+    it('does not remove dndDragover CSS class if dragover is called right after dragleave', inject(function($timeout) {
+      expect(element.hasClass('dndDragover')).toBe(true);      
+      createEvent('dragleave')._triggerOn(element);
+      $timeout.flush(10);
+      expect(element.hasClass('dndDragover')).toBe(true); 
+      //simulate dragover again
+      event = createEvent('dragover');
+      event.originalEvent.target = element[0];
+      event._triggerOn(element);
+      
+      $timeout.flush(100);
+      expect(element.hasClass('dndDragover')).toBe(true);   
+    }))
+
+    it('does not remove the placeholder if dragover is called right after dragleave', inject(function($timeout) {
+      createEvent('dragleave')._triggerOn(element);
+      $timeout.flush(10);
+      expect(element.children().length).toBe(4);
+      //simulate dragover again
+      event = createEvent('dragover');
+      event.originalEvent.target = element[0];
+      event._triggerOn(element);
+      
+      $timeout.flush(100);
+      expect(element.children().length).toBe(4);            
+    }))
   });
 
   function commonTests(eventType) {


### PR DESCRIPTION
This PR addresses the issue of dragleave being fired when dragging over child elements and having to check dndDragover class after 100ms to determine if placeholder should be removed. From comment

```
* We have to remove the placeholder when the element is no longer dragged over our list. The
* problem is that the dragleave event is not only fired when the element leaves our list,
* but also when it leaves a child element -- so practically it's fired all the time. As a
* workaround we wait a few milliseconds and then check if the dndDragover class was added
* again. If it is there, dragover must have been called in the meantime, i.e. the element
* is still dragging over the list. If you know a better way of doing this, please tell me!
```

I created this PR because we're styling our dropzones based on the dndDragover class. This class is added/removed repeatedly when dragging over child elements.  This change allows for ignoring dragLeaves when there is a dragover fired immediately after the dragleave is fired.
