### PR TITLE
Fixed unwanted execution of dragStart event handler inside dndDraggable directive

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -536,7 +536,7 @@ angular.module('dndLists', [])
           if (!(event.dataTransfer.types && event.dataTransfer.types.length)) {
             event.preventDefault();
           }
-          event.stopPropagation();
+          event.stopImmediatePropagation();
         }
       });
 
@@ -547,7 +547,7 @@ angular.module('dndLists', [])
       element.on('dragend', function(event) {
         event = event.originalEvent || event;
         if (!event._dndHandle) {
-          event.stopPropagation();
+          event.stopImmediatePropagation();
         }
       });
     };


### PR DESCRIPTION
When you use both directives (dnd-draggable and dnd-nodrag) on the same element, dnd-nodrag will not work as expected because it will only prevent the `dragstart` and `dragend` events from bubbling up but won't prevent the rest of element event handlers from firing up.