### PR TITLE
added functionality that dnd-type can be a number

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -99,7 +99,7 @@
 
         // Initialize global state.
         dndState.isDragging = true;
-        dndState.itemType = attr.dndType && scope.$eval(attr.dndType).toLowerCase();
+        dndState.itemType = attr.dndType && (scope.$eval(attr.dndType) + '').toLowerCase();
 
         // Set the allowed drop effects. See below for special IE handling.
         dndState.dropEffect = "none";


### PR DESCRIPTION
yet dnd-allowed-types is able to take a array of strings or numbers but dnd-type on the subelement just takes a string. now its also possible to give a number which is useful in not few cases