### PR TITLE
Add export module to use with es6 syntax import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-drag-and-drop-lists.js');
+module.exports = 'dndLists';


### PR DESCRIPTION
With this feature we can use import syntax.

Example: import dndLists from 'angular-drag-and-drop-lists/index'