### PR TITLE
Drag and drop now significantly faster with large lists

### DIFF
--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -278,6 +278,8 @@
 
       var placeholderNode = placeholder[0];
       var dragDropReplacementElement;
+      var previousTarget;
+      var newTarget;
       var listNode = element[0];
       var listSettings = {};
 
@@ -309,12 +311,28 @@
        * is being dragged over our list, or over an child element.
        */
       element.on('dragover', function(event) {
+        if (!newTarget) {
+          newTarget = event.target
+        }
+        if (event.target != newTarget) {
+          previousTarget = newTarget
+          newTarget = event.target
+          previousTarget.parentNode.style.border = '1px solid #9aa5af'
+        }
+        console.log(`dragover event: ${event}`)
+        // element.on('dragover', _.throttle(dragOver, 50, { leading: true, trailing: false }))
+        // function dragOver(event){
         event = event.originalEvent || event;
 
         // Check whether the drop is allowed and determine mime type.
         var mimeType = getMimeType(event.dataTransfer.types);
         var itemType = getItemType(mimeType);
         if (!mimeType || !isDropAllowed(itemType)) return true;
+
+        // Make sure the placeholder is shown, which is especially important if the list is empty.
+        // if (placeholderNode.parentNode != listNode) {
+        //   element.append('<div>ALALALLALALALAALALL</div>');
+        // }
 
         if (event.target != listNode) {
           // Try to find the node direct directly below the list node.
@@ -324,6 +342,7 @@
           }
 
           if (listItemNode.parentNode == listNode && listItemNode != placeholderNode) {
+            console.log(`listItemNode.children: ${listItemNode.children} listItemNode.parentNode.children: ${listItemNode.parentNode.children}`)
             // If the mouse pointer is in the upper half of the list item element,
             // we position the placeholder before the list item, otherwise after it.
             var rect = listItemNode.getBoundingClientRect();
@@ -334,10 +353,17 @@
             }
             if(isFirstHalf) {
               dragDropReplacementElement = listItemNode;
+              newTarget.style.borderTop = '3px solid blue';
+              // console.log(`dragDropReplacementElement.children(): ${dragDropReplacementElement.children()}`);
+              // listItemNode.css("border-top", "1px solid blue");
             } else {
               dragDropReplacementElement = listItemNode.nextSibling;
+              newTarget.style.borderTop = '3px solid blue';
             }
           }
+        }
+        else {
+          event.target.style.borderTop = '1px solid blue';
         }
 
         // In IE we set a fake effectAllowed in dragstart to get the correct cursor, we therefore
@@ -404,12 +430,15 @@
 
         // Invoke the callback, which can transform the transferredObject and even abort the drop.
         var index = getPlaceholderIndex();
+        // var index = Array.prototype.indexOf.call(listNode.children, dragDropReplacementElement);
         if (attr.dndDrop) {
           data = invokeCallback(attr.dndDrop, event, dropEffect, itemType, index, data);
           if (!data) return stopDragover();
         }
 
-        listNode.insertBefore(listNode.children[index], data)
+        if (data) {
+          listNode.insertBefore(listNode.children[index], data)
+        }
 
         // The drop is definitely going to happen now, store the dropEffect.
         dndState.dropEffect = dropEffect;

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -271,12 +271,6 @@
    */
   dndLists.directive('dndList', ['$parse', function($parse) {
     return function(scope, element, attr) {
-      // While an element is dragged over the list, this placeholder element is inserted
-      // at the location where the element would be inserted after dropping.
-      var placeholder = getPlaceholderElement();
-      placeholder.remove();
-
-      var placeholderNode = placeholder[0];
       var dragDropReplacementElement;
       var previousTarget;
       var newTarget;
@@ -333,7 +327,7 @@
             listItemNode = listItemNode.parentNode;
           }
 
-          if (listItemNode.parentNode == listNode && listItemNode != placeholderNode) {
+          if (listItemNode.parentNode == listNode) {
             // If the mouse pointer is in the upper half of the list item element,
             // we position the placeholder before the list item, otherwise after it.
             var rect = listItemNode.getBoundingClientRect();
@@ -535,7 +529,6 @@
        * Small helper function that cleans up if we aborted a drop.
        */
       function stopDragover() {
-        placeholder.remove();
         element.removeClass("dndDragover");
         return true;
       }
@@ -561,21 +554,6 @@
        */
       function getDropDestinationNeighborIndex() {
         return [...dragDropReplacementElement.parentElement.children].indexOf(dragDropReplacementElement);
-      }
-
-      /**
-       * Tries to find a child element that has the dndPlaceholder class set. If none was found, a
-       * new li element is created.
-       */
-      function getPlaceholderElement() {
-        var placeholder;
-        angular.forEach(element.children(), function(childNode) {
-          var child = angular.element(childNode);
-          if (child.hasClass('dndPlaceholder')) {
-            placeholder = child;
-          }
-        });
-        return placeholder || angular.element("<li class='dndPlaceholder'></li>");
       }
     };
   }]);

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -317,7 +317,7 @@
         if (event.target != newTarget) {
           previousTarget = newTarget
           newTarget = event.target
-          previousTarget.parentNode.style.borderTop = 'none'
+          previousTarget.closest(".item-row").style.borderTop = 'none'
         }
         // console.log(`dragover event: ${event}`)
         // element.on('dragover', _.throttle(dragOver, 50, { leading: true, trailing: false }))
@@ -353,12 +353,12 @@
             }
             if(isFirstHalf) {
               dragDropReplacementElement = listItemNode;
-              newTarget.parentNode.style.borderTop = '3px solid blue';
+              newTarget.closest(".item-row").style.borderTop = '3px solid blue';
               // console.log(`dragDropReplacementElement.children(): ${dragDropReplacementElement.children()}`);
               // listItemNode.css("border-top", "1px solid blue");
             } else {
               dragDropReplacementElement = listItemNode.nextSibling;
-              newTarget.parentNode.style.borderTop = '3px solid blue';
+              newTarget.closest(".item-row").style.borderTop = '3px solid blue';
             }
           }
         }
@@ -395,7 +395,7 @@
        */
       element.on('drop', function(event) {
         event = event.originalEvent || event;
-        newTarget.parentNode.style.borderTop = 'none'
+        newTarget.closest(".item-row").style.borderTop = 'none'
 
         // Check whether the drop is allowed and determine mime type.
         var mimeType = getMimeType(event.dataTransfer.types);

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -317,9 +317,9 @@
         if (event.target != newTarget) {
           previousTarget = newTarget
           newTarget = event.target
-          previousTarget.parentNode.style.border = '1px solid #9aa5af'
+          previousTarget.parentNode.style.borderTop = 'none'
         }
-        console.log(`dragover event: ${event}`)
+        // console.log(`dragover event: ${event}`)
         // element.on('dragover', _.throttle(dragOver, 50, { leading: true, trailing: false }))
         // function dragOver(event){
         event = event.originalEvent || event;
@@ -342,7 +342,7 @@
           }
 
           if (listItemNode.parentNode == listNode && listItemNode != placeholderNode) {
-            console.log(`listItemNode.children: ${listItemNode.children} listItemNode.parentNode.children: ${listItemNode.parentNode.children}`)
+            // console.log(`listItemNode.children: ${listItemNode.children} listItemNode.parentNode.children: ${listItemNode.parentNode.children}`)
             // If the mouse pointer is in the upper half of the list item element,
             // we position the placeholder before the list item, otherwise after it.
             var rect = listItemNode.getBoundingClientRect();
@@ -353,17 +353,14 @@
             }
             if(isFirstHalf) {
               dragDropReplacementElement = listItemNode;
-              newTarget.style.borderTop = '3px solid blue';
+              newTarget.parentNode.style.borderTop = '3px solid blue';
               // console.log(`dragDropReplacementElement.children(): ${dragDropReplacementElement.children()}`);
               // listItemNode.css("border-top", "1px solid blue");
             } else {
               dragDropReplacementElement = listItemNode.nextSibling;
-              newTarget.style.borderTop = '3px solid blue';
+              newTarget.parentNode.style.borderTop = '3px solid blue';
             }
           }
-        }
-        else {
-          event.target.style.borderTop = '1px solid blue';
         }
 
         // In IE we set a fake effectAllowed in dragstart to get the correct cursor, we therefore
@@ -398,6 +395,7 @@
        */
       element.on('drop', function(event) {
         event = event.originalEvent || event;
+        newTarget.parentNode.style.borderTop = 'none'
 
         // Check whether the drop is allowed and determine mime type.
         var mimeType = getMimeType(event.dataTransfer.types);

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -277,6 +277,7 @@
       placeholder.remove();
 
       var placeholderNode = placeholder[0];
+      var dragDropReplacementElement;
       var listNode = element[0];
       var listSettings = {};
 
@@ -315,11 +316,6 @@
         var itemType = getItemType(mimeType);
         if (!mimeType || !isDropAllowed(itemType)) return true;
 
-        // Make sure the placeholder is shown, which is especially important if the list is empty.
-        if (placeholderNode.parentNode != listNode) {
-          element.append(placeholder);
-        }
-
         if (event.target != listNode) {
           // Try to find the node direct directly below the list node.
           var listItemNode = event.target;
@@ -337,9 +333,9 @@
               var isFirstHalf = event.clientY < rect.top + rect.height / 2;
             }
             if(isFirstHalf) {
-              if(listItemNode.previousSibling != placeholderNode) listNode.insertBefore(placeholderNode, listItemNode);
+              dragDropReplacementElement = listItemNode;
             } else {
-              if(listItemNode.nextSibling != placeholderNode) listNode.insertBefore(placeholderNode, listItemNode.nextSibling);
+              dragDropReplacementElement = listItemNode.nextSibling;
             }
           }
         }
@@ -405,12 +401,15 @@
         var dropEffect = getDropEffect(event, ignoreDataTransfer);
         if (dropEffect == 'none') return stopDragover();
 
+
         // Invoke the callback, which can transform the transferredObject and even abort the drop.
         var index = getPlaceholderIndex();
         if (attr.dndDrop) {
           data = invokeCallback(attr.dndDrop, event, dropEffect, itemType, index, data);
           if (!data) return stopDragover();
         }
+
+        listNode.insertBefore(listNode.children[index], data)
 
         // The drop is definitely going to happen now, store the dropEffect.
         dndState.dropEffect = dropEffect;
@@ -546,6 +545,7 @@
        * object needs to be inserted
        */
       function getPlaceholderIndex() {
+        listNode.insertBefore(placeholderNode, dragDropReplacementElement);
         return Array.prototype.indexOf.call(listNode.children, placeholderNode);
       }
 

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -311,7 +311,9 @@
         if (event.target != newTarget) {
           previousTarget = newTarget
           newTarget = event.target
-          previousTarget.closest(".item-row").style.borderTop = 'none'
+          if (previousTarget.closest(".item-row")) {
+            previousTarget.closest(".item-row").style.borderTop = 'none'
+          }
         }
         event = event.originalEvent || event;
 
@@ -338,10 +340,14 @@
             }
             if(isFirstHalf) {
               dragDropReplacementElement = listItemNode;
-              newTarget.closest(".item-row").style.borderTop = '3px solid blue';
+              if (newTarget.closest(".item-row")) {
+                newTarget.closest(".item-row").style.borderTop = '3px solid blue';
+              }
             } else {
               dragDropReplacementElement = listItemNode.nextSibling;
-              newTarget.closest(".item-row").style.borderTop = '3px solid blue';
+              if (newTarget.closest(".item-row")) {
+                newTarget.closest(".item-row").style.borderTop = '3px solid blue';
+              }
             }
           }
         }
@@ -378,8 +384,9 @@
        */
       element.on('drop', function(event) {
         event = event.originalEvent || event;
-        newTarget.closest(".item-row").style.borderTop = 'none'
-
+        if (newTarget.closest(".item-row")) {
+          newTarget.closest(".item-row").style.borderTop = 'none'
+        }
         // Check whether the drop is allowed and determine mime type.
         var mimeType = getMimeType(event.dataTransfer.types);
         var itemType = getItemType(mimeType);

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -560,7 +560,11 @@
        * object needs to be inserted
        */
       function getDropDestinationNeighborIndex() {
-        return [...dragDropReplacementElement.parentElement.children].indexOf(dragDropReplacementElement);
+        if (dragDropReplacementElement) {
+          return [...dragDropReplacementElement.parentElement.children].indexOf(dragDropReplacementElement);
+        } else {
+          return null;
+        }
       }
     };
   }]);

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -336,8 +336,11 @@
             } else {
               var isFirstHalf = event.clientY < rect.top + rect.height / 2;
             }
-            listNode.insertBefore(placeholderNode,
-                isFirstHalf ? listItemNode : listItemNode.nextSibling);
+            if(isFirstHalf) {
+              if(listItemNode.previousSibling != placeholderNode) listNode.insertBefore(placeholderNode, listItemNode);
+            } else {
+              if(listItemNode.nextSibling != placeholderNode) listNode.insertBefore(placeholderNode, listItemNode.nextSibling);
+            }
           }
         }
 

--- a/angular-drag-and-drop-lists.js
+++ b/angular-drag-and-drop-lists.js
@@ -319,20 +319,12 @@
           newTarget = event.target
           previousTarget.closest(".item-row").style.borderTop = 'none'
         }
-        // console.log(`dragover event: ${event}`)
-        // element.on('dragover', _.throttle(dragOver, 50, { leading: true, trailing: false }))
-        // function dragOver(event){
         event = event.originalEvent || event;
 
         // Check whether the drop is allowed and determine mime type.
         var mimeType = getMimeType(event.dataTransfer.types);
         var itemType = getItemType(mimeType);
         if (!mimeType || !isDropAllowed(itemType)) return true;
-
-        // Make sure the placeholder is shown, which is especially important if the list is empty.
-        // if (placeholderNode.parentNode != listNode) {
-        //   element.append('<div>ALALALLALALALAALALL</div>');
-        // }
 
         if (event.target != listNode) {
           // Try to find the node direct directly below the list node.
@@ -342,7 +334,6 @@
           }
 
           if (listItemNode.parentNode == listNode && listItemNode != placeholderNode) {
-            // console.log(`listItemNode.children: ${listItemNode.children} listItemNode.parentNode.children: ${listItemNode.parentNode.children}`)
             // If the mouse pointer is in the upper half of the list item element,
             // we position the placeholder before the list item, otherwise after it.
             var rect = listItemNode.getBoundingClientRect();
@@ -354,8 +345,6 @@
             if(isFirstHalf) {
               dragDropReplacementElement = listItemNode;
               newTarget.closest(".item-row").style.borderTop = '3px solid blue';
-              // console.log(`dragDropReplacementElement.children(): ${dragDropReplacementElement.children()}`);
-              // listItemNode.css("border-top", "1px solid blue");
             } else {
               dragDropReplacementElement = listItemNode.nextSibling;
               newTarget.closest(".item-row").style.borderTop = '3px solid blue';
@@ -427,14 +416,13 @@
 
 
         // Invoke the callback, which can transform the transferredObject and even abort the drop.
-        var index = getPlaceholderIndex();
-        // var index = Array.prototype.indexOf.call(listNode.children, dragDropReplacementElement);
+        var index = getDropDestinationNeighborIndex();
         if (attr.dndDrop) {
           data = invokeCallback(attr.dndDrop, event, dropEffect, itemType, index, data);
           if (!data) return stopDragover();
         }
 
-        if (data) {
+        if (typeof data === "object") {
           listNode.insertBefore(listNode.children[index], data)
         }
 
@@ -561,19 +549,18 @@
           dropEffect: dropEffect,
           event: event,
           external: !dndState.isDragging,
-          index: index !== undefined ? index : getPlaceholderIndex(),
+          index: index !== undefined ? index : getDropDestinationNeighborIndex(),
           item: item || undefined,
           type: itemType
         });
       }
 
       /**
-       * We use the position of the placeholder node to determine at which position of the array the
+       * We use the position of the node located just before/after where the object is hovering to determine at which position of the array the
        * object needs to be inserted
        */
-      function getPlaceholderIndex() {
-        listNode.insertBefore(placeholderNode, dragDropReplacementElement);
-        return Array.prototype.indexOf.call(listNode.children, placeholderNode);
+      function getDropDestinationNeighborIndex() {
+        return [...dragDropReplacementElement.parentElement.children].indexOf(dragDropReplacementElement);
       }
 
       /**

--- a/demo/nested/nested.css
+++ b/demo/nested/nested.css
@@ -121,6 +121,10 @@
     filter: none;
 }
 
+.dndDragoverIndicator {
+    border-top: 1px solid blue;
+}
+
 .nestedDemo .trashcan .dndPlaceholder {
     display: none;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@onshape/angular-drag-and-drop-lists",
     "main": "angular-drag-and-drop-lists.js",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Angular directives for sorting nested lists using the HTML5 Drag and Drop API",
     "repository": "https://github.com/marceljuenemann/angular-drag-and-drop-lists",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "angular-drag-and-drop-lists",
+    "name": "@onshape/angular-drag-and-drop-lists",
     "main": "angular-drag-and-drop-lists.js",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Angular directives for sorting nested lists using the HTML5 Drag and Drop API",
     "repository": "https://github.com/marceljuenemann/angular-drag-and-drop-lists",
     "license": "MIT",


### PR DESCRIPTION
It now uses an indicator line to show where dropped item will be inserted, similar to how the parts list currently does it. 

Using this visual indicator (a border that's dynamically added to the node hovered over) is more performant than constantly inserting and removing a placeholder element into the DOM, and therefore triggering the list to re-sort as well.


https://github.com/marceljuenemann/angular-drag-and-drop-lists/assets/4033636/c331053b-653d-4f71-9d4d-9cf7b682b7bb

